### PR TITLE
feat: add /clear slash command to reset conversation session

### DIFF
--- a/packages/agent-acp/src/acp-agent.ts
+++ b/packages/agent-acp/src/acp-agent.ts
@@ -71,6 +71,19 @@ export class AcpAgent implements Agent {
   }
 
   /**
+   * Clear/reset the session for a given conversation.
+   * The next message will automatically create a fresh session.
+   */
+  clearSession(conversationId: string): void {
+    const sessionId = this.sessions.get(conversationId);
+    if (sessionId) {
+      log(`clearing session for conversation=${conversationId} (session=${sessionId})`);
+      this.connection.unregisterCollector(sessionId);
+      this.sessions.delete(conversationId);
+    }
+  }
+
+  /**
    * Kill the ACP subprocess and clean up all sessions.
    */
   dispose(): void {

--- a/packages/sdk/src/agent/interface.ts
+++ b/packages/sdk/src/agent/interface.ts
@@ -9,6 +9,8 @@
 export interface Agent {
   /** Process a single message and return a reply. */
   chat(request: ChatRequest): Promise<ChatResponse>;
+  /** Clear/reset the session for a given conversation. */
+  clearSession?(conversationId: string): void;
 }
 
 export interface ChatRequest {

--- a/packages/sdk/src/messaging/process-message.ts
+++ b/packages/sdk/src/messaging/process-message.ts
@@ -110,16 +110,18 @@ export async function processOneMessage(
 
   // --- Slash commands ---
   if (textBody.startsWith("/")) {
+    const conversationId = full.from_user_id ?? "";
     const slashResult = await handleSlashCommand(
       textBody,
       {
-        to: full.from_user_id ?? "",
+        to: conversationId,
         contextToken: full.context_token,
         baseUrl: deps.baseUrl,
         token: deps.token,
         accountId: deps.accountId,
         log: deps.log,
         errLog: deps.errLog,
+        onClear: () => deps.agent.clearSession?.(conversationId),
       },
       receivedAt,
       full.create_time_ms,

--- a/packages/sdk/src/messaging/slash-commands.ts
+++ b/packages/sdk/src/messaging/slash-commands.ts
@@ -4,6 +4,7 @@
  * 支持的指令：
  * - /echo <message>         直接回复消息（不经过 AI），并附带通道耗时统计
  * - /toggle-debug           开关 debug 模式，启用后每条 AI 回复追加全链路耗时
+ * - /clear                  清除当前会话，重新开始对话
  */
 import type { WeixinApiOptions } from "../api/api.js";
 import { logger } from "../util/logger.js";
@@ -24,6 +25,8 @@ export interface SlashCommandContext {
   accountId: string;
   log: (msg: string) => void;
   errLog: (msg: string) => void;
+  /** Called when /clear is invoked to reset the agent session. */
+  onClear?: () => void;
 }
 
 /** 发送回复消息 */
@@ -93,6 +96,11 @@ export async function handleSlashCommand(
             ? "Debug 模式已开启"
             : "Debug 模式已关闭",
         );
+        return { handled: true };
+      }
+      case "/clear": {
+        ctx.onClear?.();
+        await sendReply(ctx, "✅ 会话已清除，重新开始对话");
         return { handled: true };
       }
       default:


### PR DESCRIPTION
## Summary
- Add `/clear` slash command support so users can reset their conversation session via WeChat
- Previously, sending `/clear` was forwarded as a raw prompt to the ACP agent, leaving the session in a broken state where subsequent messages were never received
- Now `/clear` is intercepted at the SDK layer, the old ACP session is discarded, and a fresh one is automatically created on the next message

## Changes
- `Agent` interface: added optional `clearSession(conversationId)` method
- `slash-commands.ts`: added `/clear` handler that calls `onClear` callback
- `process-message.ts`: wired `onClear` to call `agent.clearSession()`
- `AcpAgent`: implemented `clearSession()` to remove cached session

## Test plan
- [ ] Send `/clear` via WeChat, verify "✅ 会话已清除，重新开始对话" reply
- [ ] Send a follow-up message, verify it creates a new session and responds normally
- [ ] Verify existing `/echo` and `/toggle-debug` commands still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)