### PR TITLE
fix: handle ACP permission option ids and prompt timeouts

### DIFF
--- a/packages/agent-acp/src/acp-agent.ts
+++ b/packages/agent-acp/src/acp-agent.ts
@@ -10,6 +10,8 @@ function log(msg: string) {
   console.log(`[acp] ${msg}`);
 }
 
+const DEFAULT_PROMPT_TIMEOUT_MS = 120_000;
+
 /**
  * Agent adapter that bridges ACP (Agent Client Protocol) agents
  * to the weixin-agent-sdk Agent interface.
@@ -43,7 +45,7 @@ export class AcpAgent implements Agent {
     const collector = new ResponseCollector();
     this.connection.registerCollector(sessionId, collector);
     try {
-      await conn.prompt({ sessionId, prompt: blocks });
+      await this.runPromptWithTimeout(conn, sessionId, blocks);
     } finally {
       this.connection.unregisterCollector(sessionId);
     }
@@ -68,6 +70,43 @@ export class AcpAgent implements Agent {
     log(`session created: ${res.sessionId}`);
     this.sessions.set(conversationId, res.sessionId);
     return res.sessionId;
+  }
+
+  private async runPromptWithTimeout(
+    conn: Awaited<ReturnType<AcpConnection["ensureReady"]>>,
+    sessionId: SessionId,
+    prompt: ChatRequest["text"] extends string ? Awaited<ReturnType<typeof convertRequestToContentBlocks>> : never,
+  ): Promise<void> {
+    const timeoutMs = this.options.promptTimeoutMs ?? DEFAULT_PROMPT_TIMEOUT_MS;
+    const promptPromise = conn.prompt({ sessionId, prompt });
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let timedOut = false;
+
+    try {
+      await Promise.race([
+        promptPromise.then(() => undefined),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            timedOut = true;
+            log(`prompt timeout after ${timeoutMs}ms, cancelling session=${sessionId}`);
+            void conn.cancel({ sessionId }).catch((err) => {
+              log(`cancel failed for session=${sessionId}: ${String(err)}`);
+            });
+            reject(new Error(`ACP prompt timeout after ${timeoutMs}ms`));
+          }, timeoutMs);
+        }),
+      ]);
+    } catch (err) {
+      if (timedOut) {
+        await promptPromise.catch(() => {});
+      }
+      throw err;
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
   }
 
   /**

--- a/packages/agent-acp/src/acp-connection.ts
+++ b/packages/agent-acp/src/acp-connection.ts
@@ -16,6 +16,14 @@ function log(msg: string) {
   console.log(`[acp] ${msg}`);
 }
 
+function describeToolCall(update: {
+  title?: string | null;
+  kind?: string | null;
+  toolCallId?: string;
+}): string {
+  return update.title ?? update.kind ?? update.toolCallId ?? "tool";
+}
+
 /**
  * Manages the ACP agent subprocess and ClientSideConnection lifecycle.
  */
@@ -69,11 +77,11 @@ export class AcpConnection {
         const update = params.update;
         switch (update.sessionUpdate) {
           case "tool_call":
-            log(`tool_call: ${update.title} (${update.status ?? "started"})`);
+            log(`tool_call: ${describeToolCall(update)} (${update.status ?? "started"})`);
             break;
           case "tool_call_update":
             if (update.status) {
-              log(`tool_call_update: ${update.title ?? update.toolCallId} → ${update.status}`);
+              log(`tool_call_update: ${describeToolCall(update)} → ${update.status}`);
             }
             break;
           case "agent_thought_chunk":
@@ -89,11 +97,13 @@ export class AcpConnection {
       },
       requestPermission: async (params) => {
         const firstOption = params.options[0];
-        log(`permission: auto-approved "${firstOption?.id ?? "allow"}"`);
+        log(
+          `permission: auto-approved "${firstOption?.name ?? "allow"}" (${firstOption?.optionId ?? "unknown"})`,
+        );
         return {
           outcome: {
             outcome: "selected" as const,
-            optionId: firstOption?.id ?? "allow",
+            optionId: firstOption?.optionId ?? "allow",
           },
         };
       },


### PR DESCRIPTION
## Summary
- fix ACP permission auto-approval to return the correct `optionId`
- add a timeout around `conn.prompt()` and cancel stuck sessions instead of hanging forever
- improve ACP tool-call logging so pending tool calls are easier to inspect

## Testing
- pnpm --filter weixin-acp run typecheck
- pnpm --filter weixin-acp run build
- pnpm -r run typecheck